### PR TITLE
Add inputrc support, remove unneded constants, pylint fixes

### DIFF
--- a/dotfilesmanager/.pylintrc
+++ b/dotfilesmanager/.pylintrc
@@ -1,0 +1,407 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Allow optimization of some AST trees. This will activate a peephole AST
+# optimizer, which will apply various small optimizations. For instance, it can
+# be used to obtain the result of joining multiple strings with the addition
+# operator. Joining a lot of strings can lead to a maximum recursion error in
+# Pylint and this flag can prevent that. It has one side effect, the resulting
+# AST will be different than the one from reality. This option is deprecated
+# and it will be removed in Pylint 2.0.
+optimize-ast=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=zip-builtin-not-iterating,long-builtin,backtick,intern-builtin,getslice-method,long-suffix,indexing-exception,unicode-builtin,reload-builtin,cmp-builtin,import-star-module-level,standarderror-builtin,unichr-builtin,oct-method,execfile-builtin,dict-iter-method,old-ne-operator,metaclass-assignment,hex-method,no-absolute-import,basestring-builtin,nonzero-method,cmp-method,apply-builtin,print-statement,coerce-builtin,old-octal-literal,round-builtin,unpacking-in-except,coerce-method,input-builtin,old-raise-syntax,old-division,range-builtin-not-iterating,using-cmp-argument,file-builtin,parameter-unpacking,delslice-method,xrange-builtin,suppressed-message,filter-builtin-not-iterating,next-method-called,raising-string,map-builtin-not-iterating,dict-view-method,setslice-method,raw_input-builtin,useless-suppression,buffer-builtin,reduce-builtin,missing-docstring,wrong-import-position,no-member
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]". This option is deprecated
+# and it will be removed in Pylint 2.0.
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+
+[BASIC]
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[ELIF]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=(_+[a-zA-Z0-9]*?$)|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,future.builtins
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=optparse
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/dotfilesmanager/bashfile.py
+++ b/dotfilesmanager/bashfile.py
@@ -3,7 +3,7 @@ from os.path import join
 
 from dotfilesmanager import env
 from dotfilesmanager import ioutils
-from dotfilesmanager.constants import SYSTEMS, SRCFILES, DOTFILES
+from dotfilesmanager.constants import SYSTEMS, BASHFILES
 
 
 def _write_header(file_name, file_buffer):
@@ -16,24 +16,24 @@ def _write_header(file_name, file_buffer):
 
 def compile_bash_file(platform):
     if platform == SYSTEMS.DARWIN.value:
-        bash_file = DOTFILES.BASH_PROFILE.value
+        bash_file = BASHFILES.BASH_PROFILE.value
         if env.IS_GNU:
-            bash_platform_file = SRCFILES.BASH_MAC_GNU.value
+            bash_platform_file = BASHFILES.BASH_MAC_GNU.value
         else:
-            bash_platform_file = SRCFILES.BASH_MAC_BSD.value
+            bash_platform_file = BASHFILES.BASH_MAC_BSD.value
     elif platform == SYSTEMS.LINUX.value:
-        bash_file = DOTFILES.BASHRC.value
-        bash_platform_file = SRCFILES.BASH_LINUX.value
+        bash_file = BASHFILES.BASHRC.value
+        bash_platform_file = BASHFILES.BASH_LINUX.value
 
     ioutils.sprint("Compiling file: " + bash_file)
     with io.StringIO() as file_buffer:
         _write_header(bash_file, file_buffer)
         ioutils.write_required_input_file_contents(
-            SRCFILES.BASH_GLOBAL.value, file_buffer)
+            BASHFILES.BASH_GLOBAL.value, file_buffer)
         ioutils.write_optional_input_file_contents(bash_platform_file, file_buffer)
         if not env.ARGS.no_local:
             ioutils.write_optional_input_file_contents(
-                SRCFILES.BASH_LOCAL.value, file_buffer)
+                BASHFILES.BASH_LOCAL.value, file_buffer)
         ioutils.write_output_file(join(env.OUTPUT_DIR, bash_file), file_buffer)
         ioutils.sprint("File completed.\n")
 

--- a/dotfilesmanager/constants.py
+++ b/dotfilesmanager/constants.py
@@ -7,20 +7,17 @@ class SYSTEMS(Enum):
     WINDOWS = 'Windows'
 
 
-class DOTFILES(Enum):
+class BASHFILES(Enum):
     BASH_PROFILE = '.bash_profile'
     BASHRC = '.bashrc'
-    GITCONFIG = '.gitconfig'
-    VIMRC = '.vimrc'
-
-
-class SRCFILES(Enum):
     BASH_GLOBAL = 'bash_global'
     BASH_LINUX = 'bash_linux'
     BASH_LOCAL = 'bash_local'
     BASH_MAC_BSD = 'bash_mac_bsd'
     BASH_MAC_GNU = 'bash_mac_gnu'
-    GITCONFIG_GLOBAL = 'gitconfig_global'
-    GITCONFIG_LOCAL = 'gitconfig_local'
-    VIMRC_GLOBAL = 'vimrc_global'
-    VIMRC_LOCAL = 'vimrc_local'
+
+
+class DOTFILES(Enum):
+    GITCONFIG = '.gitconfig'
+    VIMRC = '.vimrc'
+    INPUTRC = '.inputrc'

--- a/dotfilesmanager/dfm.py
+++ b/dotfilesmanager/dfm.py
@@ -11,7 +11,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from dotfilesmanager import bashfile
 from dotfilesmanager import env
 from dotfilesmanager import ioutils
-from dotfilesmanager.constants import SYSTEMS, DOTFILES
+from dotfilesmanager.constants import SYSTEMS, DOTFILES, BASHFILES
 from dotfilesmanager.ioutils import sprint, eprint
 
 
@@ -101,9 +101,9 @@ def _set_env():
 
 def _print_completion_message():
     if env.PLATFORM == SYSTEMS.DARWIN.value:
-        bash_file_name = DOTFILES.BASH_PROFILE.value
+        bash_file_name = BASHFILES.BASH_PROFILE.value
     else:
-        bash_file_name = DOTFILES.BASHRC.value
+        bash_file_name = BASHFILES.BASHRC.value
     print("Done. Recommend you source ~/{0} or start new a terminal session."\
         .format(bash_file_name))
 
@@ -117,28 +117,29 @@ def main():
         if env.ARGS.revert:
             ioutils.revert_dotfile(dotfile)
         else:
-            if dotfile == DOTFILES.BASHRC.value:
+            if dotfile == BASHFILES.BASHRC.value:
                 bashfile.compile_bashrc()
-            elif dotfile == DOTFILES.BASH_PROFILE.value:
+            elif dotfile == BASHFILES.BASH_PROFILE.value:
                 bashfile.compile_bash_profile()
-            elif dotfile == DOTFILES.VIMRC.value:
-                ioutils.compile_dotfile(DOTFILES.VIMRC.value)
-            elif dotfile == DOTFILES.GITCONFIG.value:
-                ioutils.compile_dotfile(DOTFILES.GITCONFIG.value)
             else:
-                dotfiles = str([df.value for df in DOTFILES])
-                eprint(
-                    "{0} is not a recognized dotfile. \
-                    Valid dotfile names are: {1}"
-                    .format(dotfile, dotfiles))
-                exit(1)
+                dotfiles = [df.value for df in DOTFILES]
+                if dotfile in dotfiles:
+                    ioutils.compile_dotfile(dotfile)
+                else:
+                    dotfiles = str([df.value for df in DOTFILES])
+                    eprint(
+                        "{0} is not a recognized dotfile. \
+                        Valid dotfile names are: {1}"
+                        .format(dotfile, dotfiles))
+                    exit(1)
     else:
         if env.ARGS.revert:
             ioutils.revert_dotfiles([df.value for df in DOTFILES])
         else:
             bashfile.compile_bash_file(env.PLATFORM)
-            ioutils.compile_dotfile(DOTFILES.VIMRC.value)
-            ioutils.compile_dotfile(DOTFILES.GITCONFIG.value)
+            dotfiles = [df.value for df in DOTFILES]
+            for df in DOTFILES:
+                ioutils.compile_dotfile(df.value)
     _print_completion_message()
 
 if __name__ == '__main__':

--- a/dotfilesmanager/test/bashfileinttest.py
+++ b/dotfilesmanager/test/bashfileinttest.py
@@ -12,7 +12,7 @@ from dotfilesmanager.test import testfilemocks
 from dotfilesmanager import dfm
 from dotfilesmanager import bashfile
 from dotfilesmanager import ioutils
-from dotfilesmanager.constants import SYSTEMS, SRCFILES, DOTFILES
+from dotfilesmanager.constants import SYSTEMS, BASHFILES
 
 class BashFileIntTest(unittest.TestCase):
 
@@ -35,50 +35,50 @@ class BashFileIntTest(unittest.TestCase):
     def testBashGlobalAndBashMacBsdWrittenToBashProfile(self):
         testenv.IS_GNU = False
         bashfile.compile_bash_file(SYSTEMS.DARWIN.value)
-        with open(join(testenv.OUTPUT_DIR, DOTFILES.BASH_PROFILE.value)) as bashProfile:
+        with open(join(testenv.OUTPUT_DIR, BASHFILES.BASH_PROFILE.value)) as bashProfile:
             contents = bashProfile.read()
-            with open(join(testenv.INPUT_DIR, SRCFILES.BASH_GLOBAL.value)) as bashInput:
+            with open(join(testenv.INPUT_DIR, BASHFILES.BASH_GLOBAL.value)) as bashInput:
                 self.assertTrue(bashInput.read() in contents)
-            with open(join(testenv.INPUT_DIR, SRCFILES.BASH_MAC_BSD.value)) as bashInput:
+            with open(join(testenv.INPUT_DIR, BASHFILES.BASH_MAC_BSD.value)) as bashInput:
                 self.assertTrue(bashInput.read() in contents)
 
     def testBashLinuxNotWrittenToBashProfile(self):
         bashfile.compile_bash_file(SYSTEMS.DARWIN.value)
-        with open(join(testenv.OUTPUT_DIR, DOTFILES.BASH_PROFILE.value)) as bashProfile:
+        with open(join(testenv.OUTPUT_DIR, BASHFILES.BASH_PROFILE.value)) as bashProfile:
             contents = bashProfile.read()
-            with open(join(testenv.INPUT_DIR, SRCFILES.BASH_LINUX.value)) as bashInput:
+            with open(join(testenv.INPUT_DIR, BASHFILES.BASH_LINUX.value)) as bashInput:
                 self.assertTrue(bashInput.read() not in contents)
 
     def testBashLocalWrittenToBashProfileWhenArg_no_local_notPassed(self):
         bashfile.compile_bash_profile()
-        with open(join(testenv.OUTPUT_DIR, DOTFILES.BASH_PROFILE.value)) as bashProfile:
+        with open(join(testenv.OUTPUT_DIR, BASHFILES.BASH_PROFILE.value)) as bashProfile:
             contents = bashProfile.read()
-            with open(join(testenv.INPUT_DIR, SRCFILES.BASH_LOCAL.value)) as bashInput:
+            with open(join(testenv.INPUT_DIR, BASHFILES.BASH_LOCAL.value)) as bashInput:
                 self.assertTrue(bashInput.read() in contents)
 
     def testBashGlobalAndBashLinuxWrittenToBashrc(self):
         bashfile.compile_bash_file(SYSTEMS.LINUX.value)
-        with open(join(testenv.OUTPUT_DIR, DOTFILES.BASHRC.value)) as bashrc:
+        with open(join(testenv.OUTPUT_DIR, BASHFILES.BASHRC.value)) as bashrc:
             contents = bashrc.read()
-            with open(join(testenv.INPUT_DIR, SRCFILES.BASH_GLOBAL.value)) as bashInput:
+            with open(join(testenv.INPUT_DIR, BASHFILES.BASH_GLOBAL.value)) as bashInput:
                 self.assertTrue(bashInput.read() in contents)
-            with open(join(testenv.INPUT_DIR, SRCFILES.BASH_LINUX.value)) as bashInput:
+            with open(join(testenv.INPUT_DIR, BASHFILES.BASH_LINUX.value)) as bashInput:
                 self.assertTrue(bashInput.read() in contents)
 
     def testBashMacContentNotWrittenToBashrc(self):
         bashfile.compile_bash_file(SYSTEMS.LINUX.value)
-        with open(join(testenv.OUTPUT_DIR, DOTFILES.BASHRC.value)) as bashrc:
+        with open(join(testenv.OUTPUT_DIR, BASHFILES.BASHRC.value)) as bashrc:
             contents = bashrc.read()
-            with open(join(testenv.INPUT_DIR, SRCFILES.BASH_MAC_GNU.value)) as bashInput:
+            with open(join(testenv.INPUT_DIR, BASHFILES.BASH_MAC_GNU.value)) as bashInput:
                 self.assertTrue(bashInput.read() not in contents)
-            with open(join(testenv.INPUT_DIR, SRCFILES.BASH_MAC_BSD.value)) as bashInput:
+            with open(join(testenv.INPUT_DIR, BASHFILES.BASH_MAC_BSD.value)) as bashInput:
                 self.assertTrue(bashInput.read() not in contents)
 
     def testBashLocalWrittenToBashrc(self):
         bashfile.compile_bash_file(SYSTEMS.LINUX.value)
-        with open(join(testenv.OUTPUT_DIR, DOTFILES.BASHRC.value)) as bashrc:
+        with open(join(testenv.OUTPUT_DIR, BASHFILES.BASHRC.value)) as bashrc:
             contents = bashrc.read()
-            with open(join(testenv.INPUT_DIR, SRCFILES.BASH_LOCAL.value)) as bashInput:
+            with open(join(testenv.INPUT_DIR, BASHFILES.BASH_LOCAL.value)) as bashInput:
                 self.assertTrue(bashInput.read() in contents)
 
     def testBashLocalNotWrittenToBashrcWhenUserPassesArg_no_local(self):
@@ -87,9 +87,9 @@ class BashFileIntTest(unittest.TestCase):
         testenv.ARGS = testenv.parser.parse_args(['--no-local'])
 
         bashfile.compile_bash_file(SYSTEMS.LINUX.value)
-        with open(join(testenv.OUTPUT_DIR, DOTFILES.BASHRC.value)) as bashrc:
+        with open(join(testenv.OUTPUT_DIR, BASHFILES.BASHRC.value)) as bashrc:
             contents = bashrc.read()
-            with open(join(testenv.INPUT_DIR, SRCFILES.BASH_LOCAL.value)) as bashInput:
+            with open(join(testenv.INPUT_DIR, BASHFILES.BASH_LOCAL.value)) as bashInput:
                 self.assertTrue(bashInput.read() not in contents)
 
         testenv.ARGS = args
@@ -98,33 +98,33 @@ class BashFileIntTest(unittest.TestCase):
         args = testenv.ARGS
         testenv.ARGS = testenv.parser.parse_args(['-v'])
 
-        with open(join(testenv.INPUT_DIR, SRCFILES.BASH_LOCAL.value)) as bashLocal:
+        with open(join(testenv.INPUT_DIR, BASHFILES.BASH_LOCAL.value)) as bashLocal:
             bashLocalText = bashLocal.read()
-        ioutils.destroy_file(join(testenv.INPUT_DIR, SRCFILES.BASH_LOCAL.value))
+        ioutils.destroy_file(join(testenv.INPUT_DIR, BASHFILES.BASH_LOCAL.value))
         bashfile.compile_bash_file(SYSTEMS.DARWIN.value)
-        self.assertTrue(SRCFILES.BASH_LOCAL.value + " is not present. Skipping..." in sys.stdout.getvalue().strip())
-        testfilemocks.create_file(join(testenv.INPUT_DIR, SRCFILES.BASH_LOCAL.value), bashLocalText)
+        self.assertTrue(BASHFILES.BASH_LOCAL.value + " is not present. Skipping..." in sys.stdout.getvalue().strip())
+        testfilemocks.create_file(join(testenv.INPUT_DIR, BASHFILES.BASH_LOCAL.value), bashLocalText)
 
         testenv.ARGS = args
 
     def testWhenUserPassesArg_c_ThenExistingOutputFilesAreClobbered(self):
         testenv.ARGS = testenv.parser.parse_args(['-c'])
-        with open(join(testenv.OUTPUT_DIR, DOTFILES.BASH_PROFILE.value), 'w') as bash_profile:
+        with open(join(testenv.OUTPUT_DIR, BASHFILES.BASH_PROFILE.value), 'w') as bash_profile:
             bash_profile.write("some_bash_token=some_value")
         bashfile.compile_bash_profile()
         self.assertTrue("already exists. Renaming" not in sys.stdout.getvalue().strip())
-        self.assertFalse(os.path.isfile(join(testenv.OUTPUT_DIR, DOTFILES.BASH_PROFILE.value + '.bak')))
+        self.assertFalse(os.path.isfile(join(testenv.OUTPUT_DIR, BASHFILES.BASH_PROFILE.value + '.bak')))
         testenv.ARGS = ''
 
     def testBashProfileNotCreatedInHomeDirOnLinuxSystem(self):
         bashfile.compile_bash_file(SYSTEMS.LINUX.value)
-        self.assertFalse(os.path.isfile(join(testenv.OUTPUT_DIR, DOTFILES.BASH_PROFILE.value)))
-        self.assertTrue(os.path.isfile(join(testenv.OUTPUT_DIR, DOTFILES.BASHRC.value)))
+        self.assertFalse(os.path.isfile(join(testenv.OUTPUT_DIR, BASHFILES.BASH_PROFILE.value)))
+        self.assertTrue(os.path.isfile(join(testenv.OUTPUT_DIR, BASHFILES.BASHRC.value)))
 
     def testBashrcNotCreatedInHomeDirOnDarwinSystem(self):
         bashfile.compile_bash_file(SYSTEMS.DARWIN.value)
-        self.assertTrue(os.path.isfile(join(testenv.OUTPUT_DIR, DOTFILES.BASH_PROFILE.value)))
-        self.assertFalse(os.path.isfile(join(testenv.OUTPUT_DIR, DOTFILES.BASHRC.value)))
+        self.assertTrue(os.path.isfile(join(testenv.OUTPUT_DIR, BASHFILES.BASH_PROFILE.value)))
+        self.assertFalse(os.path.isfile(join(testenv.OUTPUT_DIR, BASHFILES.BASHRC.value)))
 
 if __name__ == '__main__':
     unittest.main(module=__name__, buffer=True, exit=False)

--- a/dotfilesmanager/test/bashfiletest.py
+++ b/dotfilesmanager/test/bashfiletest.py
@@ -8,15 +8,15 @@ import io
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
 from dotfilesmanager import bashfile
-from dotfilesmanager.constants import DOTFILES
+from dotfilesmanager.constants import BASHFILES
 
 class BashFileTest(unittest.TestCase):
 
     def testBashFileStartsWithShebangAndCorrectHeader(self):
         with io.StringIO() as fileBuffer:
-            bashfile._write_header(DOTFILES.BASH_PROFILE.value, fileBuffer)
+            bashfile._write_header(BASHFILES.BASH_PROFILE.value, fileBuffer)
             self.assertTrue(fileBuffer.getvalue().startswith('#!/bin/bash'))
-            self.assertTrue(fileBuffer.getvalue().index(DOTFILES.BASH_PROFILE.value) > -1)
+            self.assertTrue(fileBuffer.getvalue().index(BASHFILES.BASH_PROFILE.value) > -1)
 
 if __name__ == '__main__':
     unittest.main(module=__name__, buffer=True, exit=False)

--- a/dotfilesmanager/test/dotfilesmanagertest.py
+++ b/dotfilesmanager/test/dotfilesmanagertest.py
@@ -3,20 +3,13 @@
 import sys
 import unittest
 from unittest import mock
-import platform
 import os
-import io
-import argparse
-import builtins
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
 from dotfilesmanager import dfm
-from dotfilesmanager import ioutils
-from dotfilesmanager import bashfile
-from dotfilesmanager.constants import SYSTEMS, DOTFILES
+from dotfilesmanager.constants import SYSTEMS, DOTFILES, BASHFILES
 from dotfilesmanager.test import testenv
-from dotfilesmanager.test import testfilemocks
 
 class DotfilesManagerTest(unittest.TestCase):
 
@@ -127,7 +120,7 @@ class DotfilesManagerTest(unittest.TestCase):
     def testWhenUserPassesArgs_rf_thenOnlyTheSpecifiedFileIsReverted(self, isdir, bashfile, ioutils, _set_args):
         testenv.ARGS = testenv.parser.parse_args(['some_dir', '-r', '-f', '.bash_profile'])
         dfm.main()
-        ioutils.revert_dotfile.assert_called_with(DOTFILES.BASH_PROFILE.value)
+        ioutils.revert_dotfile.assert_called_with(BASHFILES.BASH_PROFILE.value)
         bashfile.compile_bash_files.assert_not_called()
         bashfile.compile_bashrc.assert_not_called()
         bashfile.compile_bash_profile.assert_not_called()

--- a/dotfilesmanager/test/ioutilsinttest.py
+++ b/dotfilesmanager/test/ioutilsinttest.py
@@ -14,12 +14,15 @@ from dotfilesmanager.test import testenv
 from dotfilesmanager.test import testfilemocks
 from dotfilesmanager import dfm
 from dotfilesmanager import ioutils
-from dotfilesmanager.constants import SRCFILES, DOTFILES
+from dotfilesmanager.constants import DOTFILES, BASHFILES
 
 
 class IOUtilsIntTest(unittest.TestCase):
-    fileName = DOTFILES.BASH_PROFILE.value
+    fileName = BASHFILES.BASH_PROFILE.value
     bakFileName = fileName[fileName.rfind('/') + 1 :].replace('.','')
+    gitconfig = '.gitconfig'
+    gitconfig_global = 'gitconfig_global'
+    gitconfig_local = 'gitconfig_local'
 
     @classmethod
     def setUpClass(self):
@@ -43,14 +46,14 @@ class IOUtilsIntTest(unittest.TestCase):
         self.createBashProfile()
         with io.StringIO() as buf:
             buf.write(str("some_bash_token=some_newer_value"))
-            ioutils.write_output_file(join(testenv.OUTPUT_DIR, DOTFILES.BASH_PROFILE.value), buf)
+            ioutils.write_output_file(join(testenv.OUTPUT_DIR, BASHFILES.BASH_PROFILE.value), buf)
         backup_files = os.listdir(testenv.BACKUPS_DIR)
         self.assertTrue(len(backup_files) is 1)
         with open(join(testenv.BACKUPS_DIR, backup_files[0])) as bakFile:
             self.assertTrue("some_value" in bakFile.read())
         self.cleanUpBackups()
 
-    def testWhenUserPassesArg_r_AndEnters_Y_whenPromptedThenDOTFILESAreRestoredToMostRecentBackedUpVersion(self):
+    def testWhenUserPassesArg_r_AndEnters_Y_whenPromptedThenDotfilesAreRestoredToMostRecentBackedUpVersion(self):
         self.createBashProfile()
         ioutils.create_file(join(testenv.BACKUPS_DIR, self.bakFileName + '_2016-07-07_14-40-00.bak'),  "some_bash_token=some_value")
         ioutils.create_file(join(testenv.BACKUPS_DIR, self.bakFileName + '_2016-07-07_14-43-00.bak'), "some_bash_token=some_newer_value")
@@ -62,7 +65,7 @@ class IOUtilsIntTest(unittest.TestCase):
             self.assertTrue("some_newer_value" in contents)
         self.cleanUpBackups()
 
-    def testWhenUserPassesArg_r_AndEnters_N_whenPromptedThenBackedUpDOTFILESAreNotRestored(self):
+    def testWhenUserPassesArg_r_AndEnters_N_whenPromptedThenBackedUpDotfilesAreNotRestored(self):
         self.createBashProfile()
         ioutils.create_file(join(testenv.BACKUPS_DIR, self.bakFileName + '_2016-07-07_14-40-00.bak'), "some_bash_token=some_value")
         ioutils.create_file(join(testenv.BACKUPS_DIR, self.bakFileName + '_2016-07-07_14-43-00.bak'), "some_bash_token=some_newer_value")
@@ -76,8 +79,8 @@ class IOUtilsIntTest(unittest.TestCase):
         testenv.ARGS = testenv.parser.parse_args(['--no-local'])
         ioutils.compile_dotfile(DOTFILES.GITCONFIG.value)
         with open(join(testenv.OUTPUT_DIR, DOTFILES.GITCONFIG.value)) as outputFile:
-            with open(join(testenv.INPUT_DIR, SRCFILES.GITCONFIG_GLOBAL.value)) as inputFile:
-                with open(join(testenv.INPUT_DIR, SRCFILES.GITCONFIG_LOCAL.value)) as \
+            with open(join(testenv.INPUT_DIR, self.gitconfig_global)) as inputFile:
+                with open(join(testenv.INPUT_DIR, self.gitconfig_local)) as \
                 localInputFile:
                     contents = outputFile.read()
                     self.assertTrue(inputFile.read() in contents)
@@ -86,8 +89,8 @@ class IOUtilsIntTest(unittest.TestCase):
     def testDotfileOutputFileContainsTheContentsOfDotfileAndLocalInputFile(self):
         ioutils.compile_dotfile(DOTFILES.GITCONFIG.value)
         with open(join(testenv.OUTPUT_DIR, DOTFILES.GITCONFIG.value)) as outputFile:
-            with open(join(testenv.INPUT_DIR, SRCFILES.GITCONFIG_GLOBAL.value)) as inputFile:
-                with open(join(testenv.INPUT_DIR, SRCFILES.GITCONFIG_LOCAL.value)) as \
+            with open(join(testenv.INPUT_DIR, self.gitconfig_global)) as inputFile:
+                with open(join(testenv.INPUT_DIR, self.gitconfig_local)) as \
                 localInputFile:
                     contents = outputFile.read()
                     self.assertTrue(inputFile.read() in contents)

--- a/dotfilesmanager/test/ioutilstest.py
+++ b/dotfilesmanager/test/ioutilstest.py
@@ -12,7 +12,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')
 from dotfilesmanager.test import testenv
 from dotfilesmanager import dfm
 from dotfilesmanager import ioutils
-from dotfilesmanager.constants import DOTFILES
+from dotfilesmanager.constants import BASHFILES
 
 class IOUtilsTest(unittest.TestCase):
 
@@ -46,7 +46,7 @@ class IOUtilsTest(unittest.TestCase):
     @mock.patch('builtins.open')
     def testWhenUserDoesNotPassArg_c_andDotfileBeingWrittenAlreadyExistsThenItGetsBackedUp(self, mopen, isfile, backup_file):
         with io.StringIO() as buf:
-            ioutils.write_output_file(join(testenv.OUTPUT_DIR, DOTFILES.BASHRC.value), buf)
+            ioutils.write_output_file(join(testenv.OUTPUT_DIR, BASHFILES.BASHRC.value), buf)
         backup_file.assert_called_once()
 
 if __name__ == '__main__':

--- a/dotfilesmanager/test/testfilemocks.py
+++ b/dotfilesmanager/test/testfilemocks.py
@@ -4,16 +4,22 @@ import sys
 sys.path.insert(0, sys.path[0][:sys.path[0].rfind('test')])
 
 from dotfilesmanager.test import testenv
-from dotfilesmanager.constants import SRCFILES, SRCFILES
+from dotfilesmanager.constants import BASHFILES
 from dotfilesmanager.ioutils import create_file
 
 def createInputFiles():
-    create_file(join(testenv.INPUT_DIR, SRCFILES.BASH_GLOBAL.value), 'some_global_token=some_global_value\n')
-    create_file(join(testenv.INPUT_DIR, SRCFILES.BASH_MAC_GNU.value), 'some_mac_gnu_token=some_value\n')
-    create_file(join(testenv.INPUT_DIR, SRCFILES.BASH_MAC_BSD.value), 'some_mac_bsd_token=some_value\n')
-    create_file(join(testenv.INPUT_DIR, SRCFILES.BASH_LINUX.value), 'some_linux_token=some_linux_value\n')
-    create_file(join(testenv.INPUT_DIR, SRCFILES.BASH_LOCAL.value), 'some_local_token=some_local_value\n')
-    create_file(join(testenv.INPUT_DIR, SRCFILES.GITCONFIG_GLOBAL.value), 'some_gitconfig_token=some_git_config_value')
-    create_file(join(testenv.INPUT_DIR, SRCFILES.GITCONFIG_LOCAL.value), 'some_gitconfig_local_token=some_local_git_value')
-    create_file(join(testenv.INPUT_DIR, SRCFILES.VIMRC_GLOBAL.value), 'some_vimrc_local_token=some_vimrc_value')
-    create_file(join(testenv.INPUT_DIR, SRCFILES.VIMRC_LOCAL.value), 'some_vimrc_local_token=some_local_vimrc_value')
+    gitconfig_global = 'gitconfig_global'
+    gitconfig_local = 'gitconfig_local'
+
+    vimrc_global = 'vimrc_global'
+    vimrc_local = 'vimrc_local'
+
+    create_file(join(testenv.INPUT_DIR, BASHFILES.BASH_GLOBAL.value), 'some_global_token=some_global_value\n')
+    create_file(join(testenv.INPUT_DIR, BASHFILES.BASH_MAC_GNU.value), 'some_mac_gnu_token=some_value\n')
+    create_file(join(testenv.INPUT_DIR, BASHFILES.BASH_MAC_BSD.value), 'some_mac_bsd_token=some_value\n')
+    create_file(join(testenv.INPUT_DIR, BASHFILES.BASH_LINUX.value), 'some_linux_token=some_linux_value\n')
+    create_file(join(testenv.INPUT_DIR, BASHFILES.BASH_LOCAL.value), 'some_local_token=some_local_value\n')
+    create_file(join(testenv.INPUT_DIR, gitconfig_global), 'some_gitconfig_token=some_git_config_value')
+    create_file(join(testenv.INPUT_DIR, gitconfig_local), 'some_gitconfig_local_token=some_local_git_value')
+    create_file(join(testenv.INPUT_DIR, vimrc_global), 'some_vimrc_local_token=some_vimrc_value')
+    create_file(join(testenv.INPUT_DIR, vimrc_local), 'some_vimrc_local_token=some_local_vimrc_value')


### PR DESCRIPTION
- Add support for `.inputrc`
- Refactor constants, clean up constants usage
- Genericize compilation of dotfiles that aren't `bashrc`/`bash_profile`
- Add .pylintrc
- Pylint fixes