### PR TITLE
V3.4 compile arbitrary dotfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
 *.swp
 *.swo
 *.pyc
-bash_private
-git_private
-sourced-private

--- a/dotfilesmanager/.pylintrc
+++ b/dotfilesmanager/.pylintrc
@@ -93,7 +93,7 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details
-#msg-template=
+msg-template='{msg_id}:{line:3d},{column}: {obj}: {msg}'
 
 
 [SPELLING]

--- a/dotfilesmanager/bashfile.py
+++ b/dotfilesmanager/bashfile.py
@@ -28,11 +28,11 @@ def compile_bash_file(platform):
     ioutils.sprint("Compiling file: " + bash_file)
     with io.StringIO() as file_buffer:
         _write_header(bash_file, file_buffer)
-        ioutils.write_required_input_file_contents(
+        ioutils.write_input_file_contents(
             BASHFILES.BASH_GLOBAL.value, file_buffer)
-        ioutils.write_optional_input_file_contents(bash_platform_file, file_buffer)
+        ioutils.write_input_file_contents(bash_platform_file, file_buffer)
         if not env.ARGS.no_local:
-            ioutils.write_optional_input_file_contents(
+            ioutils.write_input_file_contents(
                 BASHFILES.BASH_LOCAL.value, file_buffer)
         ioutils.write_output_file(join(env.OUTPUT_DIR, bash_file), file_buffer)
         ioutils.sprint("File completed.\n")
@@ -44,8 +44,3 @@ def compile_bash_profile():
 
 def compile_bashrc():
     compile_bash_file(SYSTEMS.LINUX.value)
-
-
-def compile_bash_files():
-    compile_bash_profile()
-    compile_bashrc()

--- a/dotfilesmanager/constants.py
+++ b/dotfilesmanager/constants.py
@@ -10,14 +10,8 @@ class SYSTEMS(Enum):
 class BASHFILES(Enum):
     BASH_PROFILE = '.bash_profile'
     BASHRC = '.bashrc'
-    BASH_GLOBAL = 'bash_global'
+    BASH_GLOBAL = 'bash'
     BASH_LINUX = 'bash_linux'
     BASH_LOCAL = 'bash_local'
     BASH_MAC_BSD = 'bash_mac_bsd'
     BASH_MAC_GNU = 'bash_mac_gnu'
-
-
-class DOTFILES(Enum):
-    GITCONFIG = '.gitconfig'
-    VIMRC = '.vimrc'
-    INPUTRC = '.inputrc'

--- a/dotfilesmanager/dfm.py
+++ b/dotfilesmanager/dfm.py
@@ -11,7 +11,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from dotfilesmanager import bashfile
 from dotfilesmanager import env
 from dotfilesmanager import ioutils
-from dotfilesmanager.constants import SYSTEMS, DOTFILES, BASHFILES
+from dotfilesmanager.constants import SYSTEMS, BASHFILES
 from dotfilesmanager.ioutils import sprint, eprint
 
 
@@ -122,24 +122,20 @@ def main():
             elif dotfile == BASHFILES.BASH_PROFILE.value:
                 bashfile.compile_bash_profile()
             else:
-                dotfiles = [df.value for df in DOTFILES]
-                if dotfile in dotfiles:
+                if dotfile in ioutils.get_dotfiles_map(env.INPUT_DIR):
                     ioutils.compile_dotfile(dotfile)
                 else:
-                    dotfiles = str([df.value for df in DOTFILES])
                     eprint(
-                        "{0} is not a recognized dotfile. \
-                        Valid dotfile names are: {1}"
-                        .format(dotfile, dotfiles))
-                    exit(1)
+                        "No input files found for {0}. Please double-check " \
+                         "the file name(s) and try again."
+                        .format(dotfile))
+                    exit(0)
     else:
         if env.ARGS.revert:
-            ioutils.revert_dotfiles([df.value for df in DOTFILES])
+            ioutils.revert_dotfiles([df for df in ioutils.get_dotfiles_map(env.INPUT_DIR)])
         else:
             bashfile.compile_bash_file(env.PLATFORM)
-            dotfiles = [df.value for df in DOTFILES]
-            for df in DOTFILES:
-                ioutils.compile_dotfile(df.value)
+            ioutils.compile_dotfiles(env.INPUT_DIR)
     _print_completion_message()
 
 if __name__ == '__main__':

--- a/dotfilesmanager/test/bashfileinttest.py
+++ b/dotfilesmanager/test/bashfileinttest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.6
 
 import sys
 import os
@@ -103,7 +103,7 @@ class BashFileIntTest(unittest.TestCase):
         ioutils.destroy_file(join(testenv.INPUT_DIR, BASHFILES.BASH_LOCAL.value))
         bashfile.compile_bash_file(SYSTEMS.DARWIN.value)
         self.assertTrue(BASHFILES.BASH_LOCAL.value + " is not present. Skipping..." in sys.stdout.getvalue().strip())
-        testfilemocks.create_file(join(testenv.INPUT_DIR, BASHFILES.BASH_LOCAL.value), bashLocalText)
+        ioutils.create_file(join(testenv.INPUT_DIR, BASHFILES.BASH_LOCAL.value), bashLocalText)
 
         testenv.ARGS = args
 

--- a/dotfilesmanager/test/bashfiletest.py
+++ b/dotfilesmanager/test/bashfiletest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.6
 
 import sys
 import os

--- a/dotfilesmanager/test/dotfilesmanagertest.py
+++ b/dotfilesmanager/test/dotfilesmanagertest.py
@@ -1,14 +1,15 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.6
 
 import sys
 import unittest
 from unittest import mock
+from unittest.mock import call
 import os
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
-from dotfilesmanager import dfm
-from dotfilesmanager.constants import SYSTEMS, DOTFILES, BASHFILES
+from dotfilesmanager import dfm, ioutils
+from dotfilesmanager.constants import SYSTEMS, BASHFILES
 from dotfilesmanager.test import testenv
 
 class DotfilesManagerTest(unittest.TestCase):
@@ -23,12 +24,12 @@ class DotfilesManagerTest(unittest.TestCase):
         testenv.clearArgs()
 
     @mock.patch('platform.system', mock.MagicMock(return_value=SYSTEMS.DARWIN.value))
-    def testDarwinSYSTEMSIdentifiedCorreectly(self):
+    def testDarwinSystemsIdentifiedCorreectly(self):
         dfm._identify_system()
         self.assertEqual(testenv.PLATFORM, SYSTEMS.DARWIN.value)
 
     @mock.patch('platform.system', mock.MagicMock(return_value=SYSTEMS.LINUX.value))
-    def testLinuxSYSTEMSIdentifiedCorrectly(self):
+    def testLinuxSystemsIdentifiedCorrectly(self):
         dfm._identify_system()
         self.assertEqual(testenv.PLATFORM, SYSTEMS.LINUX.value)
 
@@ -49,11 +50,13 @@ class DotfilesManagerTest(unittest.TestCase):
     @mock.patch('dotfilesmanager.dfm.ioutils', autospec=True)
     @mock.patch('dotfilesmanager.dfm.bashfile', autospec=True)
     @mock.patch('os.path.isdir', return_value=True)
-    def testWhenUserPassesArg_r_thenCorrectLogicalBranchingOccurs(self, isdir, bashfile, ioutils, _set_args):
+    @mock.patch('dotfilesmanager.dfm.ioutils.get_dotfiles_map', \
+            return_value={'.fooconfig' : ['fooconfig', 'fooconfig_local'], '.barconfig' : ['barconfig']})
+    def testWhenUserPassesArg_r_thenCorrectLogicalBranchingOccurs(self, get_dotfiles_map, isdir, bashfile, ioutils, _set_args):
         testenv.ARGS = testenv.parser.parse_args(['some_dir', '-r'])
         dfm.main()
-        ioutils.revert_dotfiles.assert_called_with([ df.value for df in DOTFILES ])
-        bashfile.compile_bash_files.assert_not_called()
+        ioutils.get_dotfiles_map.assert_called_with(testenv.INPUT_DIR)
+        ioutils.revert_dotfiles.assert_called_with([ df for dotfile in ioutils.get_dotfiles_map() ])
 
     @mock.patch('os.path.isdir', return_value=True)
     def testWhenUserPassesArg_o_thenCorrectOutputDirIsStoredInEnv(self, isdir):
@@ -83,35 +86,28 @@ class DotfilesManagerTest(unittest.TestCase):
         ioutils.compile_dotfile.assert_not_called()
 
     @mock.patch('dotfilesmanager.dfm._set_args')
-    @mock.patch('dotfilesmanager.dfm.ioutils')
+    @mock.patch('dotfilesmanager.dfm.ioutils.compile_dotfile')
     @mock.patch('dotfilesmanager.dfm.bashfile')
     @mock.patch('os.path.isdir', return_value=True)
-    def testWhenUserPassesArg_f_vimrc_thenOnlyTheSpecifiedFileIsCompiled(self, isdir, bashfile, ioutils, _set_args):
-        testenv.ARGS = testenv.parser.parse_args(['some_dir', '-f', '.vimrc'])
+    @mock.patch('dotfilesmanager.dfm.ioutils.get_dotfiles_map', return_value={'.gitconfig' : ['gitconfig', 'gitconfig_local']})
+    def testWhenUserPassesArg_f_gitconfig_thenOnlyTheSpecifiedFileIsCompiled(self, get_dotfiles_map, isdir, bashfile, compile_dotfile, _set_args):
+        dotfile = '.gitconfig'
+        testenv.ARGS = testenv.parser.parse_args(['some_dir', '-f', dotfile])
         dfm.main()
         bashfile.compile_bashrc.assert_not_called()
         bashfile.compile_bash_profile.assert_not_called()
-        ioutils.compile_dotfile.assert_called_with(DOTFILES.VIMRC.value)
-
-    @mock.patch('dotfilesmanager.dfm._set_args')
-    @mock.patch('dotfilesmanager.dfm.ioutils')
-    @mock.patch('dotfilesmanager.dfm.bashfile')
-    @mock.patch('os.path.isdir', return_value=True)
-    def testWhenUserPassesArg_f_gitconfig_thenOnlyTheSpecifiedFileIsCompiled(self, isdir, bashfile, ioutils, _set_args):
-        testenv.ARGS = testenv.parser.parse_args(['some_dir', '-f', '.gitconfig'])
-        dfm.main()
-        bashfile.compile_bashrc.assert_not_called()
-        bashfile.compile_bash_profile.assert_not_called()
-        ioutils.compile_dotfile.assert_called_with(DOTFILES.GITCONFIG.value)
+        ioutils.compile_dotfile.assert_called_once()
+        ioutils.compile_dotfile.assert_called_with(dotfile)
 
     @mock.patch('dotfilesmanager.dfm._set_args')
     @mock.patch('os.path.isdir', return_value=True)
-    def testWhenUserPassesArg_f_andAnInvalidDotfileNameThenPrintAnErrorAndExitWithCode1(self, isdir, _set_args):
-        dfm.env.ARGS = testenv.parser.parse_args(['some_dir', '-f', 'foobar'])
+    @mock.patch('dotfilesmanager.dfm.ioutils.get_dotfiles_map', return_value={'.gitconfig' : ['gitconfig', 'gitconfig_local']})
+    def testWhenUserPassesArg_f_andAnInvalidDotfileNameThenPrintAWarningAndExit(self, get_dotfiles_map, isdir, _set_args):
+        dfm.env.ARGS = testenv.parser.parse_args(['some_dir', '-v', '-f', 'foobar'])
         with self.assertRaises(SystemExit) as se:
             dfm.main()
-        self.assertEqual(se.exception.code, 1)
-        self.assertTrue("Valid dotfile names are:" in sys.stderr.getvalue())
+        self.assertEqual(se.exception.code, 0)
+        self.assertTrue("No input files found" in sys.stderr.getvalue())
 
     @mock.patch('dotfilesmanager.dfm._set_args')
     @mock.patch('dotfilesmanager.dfm.ioutils')
@@ -121,7 +117,6 @@ class DotfilesManagerTest(unittest.TestCase):
         testenv.ARGS = testenv.parser.parse_args(['some_dir', '-r', '-f', '.bash_profile'])
         dfm.main()
         ioutils.revert_dotfile.assert_called_with(BASHFILES.BASH_PROFILE.value)
-        bashfile.compile_bash_files.assert_not_called()
         bashfile.compile_bashrc.assert_not_called()
         bashfile.compile_bash_profile.assert_not_called()
         ioutils.compile_dotfile.assert_not_called()
@@ -137,6 +132,18 @@ class DotfilesManagerTest(unittest.TestCase):
             dfm._set_env()
         self.assertEqual(se.exception.code, 1)
         self.assertTrue("Specified input directory " + input_dir + " does not exist." in sys.stderr.getvalue())
+
+    @mock.patch('dotfilesmanager.dfm._set_args')
+    @mock.patch('dotfilesmanager.bashfile.compile_bash_file')
+    @mock.patch('os.path.isdir', return_value=True)
+    @mock.patch('os.path.isfile', return_value=True)
+    @mock.patch('os.listdir', return_value=['foorc', 'foorc_local', 'bar.config'])
+    @mock.patch('dotfilesmanager.ioutils.compile_dotfile')
+    def testArbitraryDotfilesAreCompiledAccordingToInputFileNameConvention(self, compile_dotfile, listdir, isfile, isdir, compile_bash_file, set_args):
+        testenv.ARGS = testenv.parser.parse_args(['some_dir'])
+        dfm.main()
+        expectedCalls = [ call('.foorc'), call('.bar.config') ]
+        ioutils.compile_dotfile.assert_has_calls(expectedCalls)
 
 if __name__ == '__main__':
     unittest.main(module=__name__, buffer=True, exit=False)

--- a/dotfilesmanager/test/ioutilsinttest.py
+++ b/dotfilesmanager/test/ioutilsinttest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.6
 
 import sys
 import io
@@ -14,14 +14,14 @@ from dotfilesmanager.test import testenv
 from dotfilesmanager.test import testfilemocks
 from dotfilesmanager import dfm
 from dotfilesmanager import ioutils
-from dotfilesmanager.constants import DOTFILES, BASHFILES
+from dotfilesmanager.constants import BASHFILES
 
 
 class IOUtilsIntTest(unittest.TestCase):
     fileName = BASHFILES.BASH_PROFILE.value
     bakFileName = fileName[fileName.rfind('/') + 1 :].replace('.','')
     gitconfig = '.gitconfig'
-    gitconfig_global = 'gitconfig_global'
+    gitconfig = 'gitconfig'
     gitconfig_local = 'gitconfig_local'
 
     @classmethod
@@ -77,9 +77,9 @@ class IOUtilsIntTest(unittest.TestCase):
 
     def testWhenUserPassesArg_no_localThenOutputFileDoesNotContainContentsOfLocalInputFile(self):
         testenv.ARGS = testenv.parser.parse_args(['--no-local'])
-        ioutils.compile_dotfile(DOTFILES.GITCONFIG.value)
-        with open(join(testenv.OUTPUT_DIR, DOTFILES.GITCONFIG.value)) as outputFile:
-            with open(join(testenv.INPUT_DIR, self.gitconfig_global)) as inputFile:
+        ioutils.compile_dotfile(self.gitconfig)
+        with open(join(testenv.OUTPUT_DIR, self.gitconfig)) as outputFile:
+            with open(join(testenv.INPUT_DIR, self.gitconfig)) as inputFile:
                 with open(join(testenv.INPUT_DIR, self.gitconfig_local)) as \
                 localInputFile:
                     contents = outputFile.read()
@@ -87,9 +87,9 @@ class IOUtilsIntTest(unittest.TestCase):
                     self.assertTrue(localInputFile.read() not in contents)
 
     def testDotfileOutputFileContainsTheContentsOfDotfileAndLocalInputFile(self):
-        ioutils.compile_dotfile(DOTFILES.GITCONFIG.value)
-        with open(join(testenv.OUTPUT_DIR, DOTFILES.GITCONFIG.value)) as outputFile:
-            with open(join(testenv.INPUT_DIR, self.gitconfig_global)) as inputFile:
+        ioutils.compile_dotfile(self.gitconfig)
+        with open(join(testenv.OUTPUT_DIR, self.gitconfig)) as outputFile:
+            with open(join(testenv.INPUT_DIR, self.gitconfig)) as inputFile:
                 with open(join(testenv.INPUT_DIR, self.gitconfig_local)) as \
                 localInputFile:
                     contents = outputFile.read()

--- a/dotfilesmanager/test/ioutilstest.py
+++ b/dotfilesmanager/test/ioutilstest.py
@@ -1,10 +1,11 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.6
 
 import sys
 import unittest
 from unittest import mock
+from unittest.mock import ANY
 import os
-from os.path import join
+from os.path import join, isfile
 import io
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
@@ -25,21 +26,15 @@ class IOUtilsTest(unittest.TestCase):
     def tearDown(self):
         testenv.clearArgs()
 
-    def testWhenDOTFILESIsRunWith_v_flagThenOutputIsVerbose(self):
+    def testWhenRunWith_v_flagThenOutputIsVerbose(self):
         testenv.ARGS = testenv.parser.parse_args(['-v'])
         ioutils.sprint("Compiling dotfiles!")
         self.assertTrue("Compiling dotfiles!" in sys.stdout.getvalue().strip())
         testenv.ARGS = testenv.parser.parse_args([])
 
-    def testWhenDOTFILESIsRunWithout_v_flagThenOutputIsNotVerbose(self):
+    def testWhenRunWithout_v_flagThenOutputIsNotVerbose(self):
         ioutils.sprint("Compiling dotfiles!")
         self.assertFalse("Compiling dotfiles!" in sys.stdout.getvalue().strip())
-
-    def testWhenRequiredInputFileDoesNotExistThenAnErrorIsPrintedAndProgramExitsWithStatus_1(self):
-        with self.assertRaises(SystemExit) as cm:
-            ioutils.write_required_input_file_contents("foo", "bar")
-        self.assertTrue("Please replace the file and try again." in sys.stderr.getvalue().strip())
-        self.assertEqual(cm.exception.code, 1)
 
     @mock.patch('dotfilesmanager.ioutils.backup_file')
     @mock.patch('os.path.isfile', return_value=True)
@@ -48,6 +43,27 @@ class IOUtilsTest(unittest.TestCase):
         with io.StringIO() as buf:
             ioutils.write_output_file(join(testenv.OUTPUT_DIR, BASHFILES.BASHRC.value), buf)
         backup_file.assert_called_once()
+
+    @mock.patch('os.path.isfile', return_value=True)
+    def testCorrectOutputFileNamesAreDerivedFromInputFiles(self, isfile):
+        inputFiles = [ 'gitconfig_local', 'vimrc' ]
+        dotfileNames = []
+        for f in inputFiles:
+            dotfileNames.append(ioutils.get_dotfile_name(f))
+        self.assertEqual(dotfileNames, [ '.gitconfig', '.vimrc' ])
+
+    @mock.patch('dotfilesmanager.dfm.ioutils.get_dotfiles_map', \
+            return_value={'.fooconfig' : ['fooconfig', 'fooconfig_local']})
+    @mock.patch('dotfilesmanager.ioutils.write_output_file')
+    def testCorrectOutputFileNamesAreWritten(self, write_output_file, get_dotfiles_map):
+        ioutils.compile_dotfiles(testenv.INPUT_DIR)
+        write_output_file.assert_called_with(join(testenv.OUTPUT_DIR, '.fooconfig'), ANY)
+
+    @mock.patch('os.listdir', return_value=[ 'bash', 'bash_mac_gnu', 'gitconfig', 'vimrc' ])
+    @mock.patch('os.path.isfile', return_value=True)
+    def testDotfilesMapIsConstructedCorrectly(self, listdir, isfile):
+        expected = set({ '.gitconfig' : [ '.gitconfig' ], '.vimrc': [ 'vimrc' ]})
+        self.assertEqual(set(ioutils.get_dotfiles_map(testenv.INPUT_DIR)), expected)
 
 if __name__ == '__main__':
     unittest.main(module=__name__, buffer=True, exit=False)

--- a/dotfilesmanager/test/testenv.py
+++ b/dotfilesmanager/test/testenv.py
@@ -6,10 +6,10 @@ import argparse
 
 from dotfilesmanager.test import testfilemocks
 
-TMP = join(tempfile.gettempdir(), 'dfm')
-INPUT_DIR = join(TMP, 'testsrc/')
-OUTPUT_DIR = join(TMP, 'testoutputfiles/')
-BACKUPS_DIR = join(TMP, 'testbackups/')
+TMP_DIR = join(tempfile.gettempdir(), 'dfm')
+INPUT_DIR = join(TMP_DIR, 'testsrc/')
+OUTPUT_DIR = join(TMP_DIR, 'testoutputfiles/')
+BACKUPS_DIR = join(TMP_DIR, 'testbackups/')
 IS_GNU = False
 parser = argparse.ArgumentParser()
 ARGS = ''
@@ -19,7 +19,7 @@ def setUp():
     testfilemocks.createInputFiles()
 
 def setUpDirs():
-    for dir in [TMP, INPUT_DIR, OUTPUT_DIR, BACKUPS_DIR]:
+    for dir in [TMP_DIR, INPUT_DIR, OUTPUT_DIR, BACKUPS_DIR]:
         if not os.path.exists(dir):
             os.mkdir(dir)
 
@@ -27,4 +27,4 @@ def clearArgs():
     ARGS = parser.parse_args([])
 
 def tearDown():
-    shutil.rmtree(TMP)
+    shutil.rmtree(TMP_DIR)

--- a/dotfilesmanager/test/testfilemocks.py
+++ b/dotfilesmanager/test/testfilemocks.py
@@ -8,10 +8,10 @@ from dotfilesmanager.constants import BASHFILES
 from dotfilesmanager.ioutils import create_file
 
 def createInputFiles():
-    gitconfig_global = 'gitconfig_global'
+    gitconfig = 'gitconfig'
     gitconfig_local = 'gitconfig_local'
 
-    vimrc_global = 'vimrc_global'
+    vimrc= 'vimrc'
     vimrc_local = 'vimrc_local'
 
     create_file(join(testenv.INPUT_DIR, BASHFILES.BASH_GLOBAL.value), 'some_global_token=some_global_value\n')
@@ -19,7 +19,7 @@ def createInputFiles():
     create_file(join(testenv.INPUT_DIR, BASHFILES.BASH_MAC_BSD.value), 'some_mac_bsd_token=some_value\n')
     create_file(join(testenv.INPUT_DIR, BASHFILES.BASH_LINUX.value), 'some_linux_token=some_linux_value\n')
     create_file(join(testenv.INPUT_DIR, BASHFILES.BASH_LOCAL.value), 'some_local_token=some_local_value\n')
-    create_file(join(testenv.INPUT_DIR, gitconfig_global), 'some_gitconfig_token=some_git_config_value')
+    create_file(join(testenv.INPUT_DIR, gitconfig), 'some_gitconfig_token=some_git_config_value')
     create_file(join(testenv.INPUT_DIR, gitconfig_local), 'some_gitconfig_local_token=some_local_git_value')
-    create_file(join(testenv.INPUT_DIR, vimrc_global), 'some_vimrc_local_token=some_vimrc_value')
+    create_file(join(testenv.INPUT_DIR, vimrc), 'some_vimrc_local_token=some_vimrc_value')
     create_file(join(testenv.INPUT_DIR, vimrc_local), 'some_vimrc_local_token=some_local_vimrc_value')


### PR DESCRIPTION
- Input file naming scheme changes:
  - Drop predefined required/optional input files (except bash files)
  - `_global` suffix no longer needed
- Add support for compilation of arbitrary dotfiles located in `$INPUT_DIR`
- Revert feature now infers what files to revert based on contents of `$INPUT_DIR`