### PR TITLE
v4.2: Output File Symlinking

### DIFF
--- a/dotfilesmanager/dfm.py
+++ b/dotfilesmanager/dfm.py
@@ -63,6 +63,10 @@ def _set_args():
         action='store_true',
         help="Don't write anything to disk, but instead report what \
                 action(s) would be taken. Implies --verbose.")
+    env.parser.add_argument(
+        '--no-symlinks',
+        action='store_true',
+        help="Don't symlink output dotfiles (compile a new file instead)")
     env.ARGS = env.parser.parse_args()
     sprint("\nPreparing dotfiles with args: " + " ".join(sys.argv[1:]) + "\n")
 
@@ -157,7 +161,7 @@ def _get_dotfiles_dict(input_dir):
 
 def _process_dotfile(dotfile, input_files):
     sprint("Processing file: " + dotfile)
-    if len(input_files) > 1:
+    if env.ARGS.no_symlinks or len(input_files) > 1:
         ioutils.compile_dotfile(dotfile, input_files)
     else:
         ioutils.create_symlink(join(env.INPUT_DIR, input_files[0]), \

--- a/dotfilesmanager/dfm.py
+++ b/dotfilesmanager/dfm.py
@@ -174,12 +174,12 @@ def main():
         if not dotfile.startswith("."):
             dotfile = "." + dotfile
         if env.ARGS.revert:
-            processed_dotfiles.append(dotfile)
             ioutils.revert_dotfile(dotfile)
+            processed_dotfiles.append(dotfile)
         else:
             if dotfile in all_dotfiles_dict:
-                processed_dotfiles.append(dotfile)
                 ioutils.compile_dotfile(dotfile, all_dotfiles_dict[dotfile])
+                processed_dotfiles.append(dotfile)
             else:
                 eprint(
                     "No input files found for {0}. Please double-check " \
@@ -188,11 +188,11 @@ def main():
                 exit(1)
     else:
         all_dotfiles = [df for df in all_dotfiles_dict]
-        processed_dotfiles.extend(all_dotfiles)
         if env.ARGS.revert:
             _revert_dotfiles(all_dotfiles)
         else:
             _compile_dotfiles(all_dotfiles_dict)
+        processed_dotfiles.extend(all_dotfiles)
     _print_completion_message(processed_dotfiles)
 
 if __name__ == '__main__':

--- a/dotfilesmanager/dfm.py
+++ b/dotfilesmanager/dfm.py
@@ -155,9 +155,17 @@ def _get_dotfiles_dict(input_dir):
     return dotfiles
 
 
-def _compile_dotfiles(all_dotfiles_dict):
+def _process_dotfile(dotfile, input_files):
+    if len(input_files) > 1:
+        ioutils.compile_dotfile(dotfile, input_files)
+    else:
+        ioutils.create_symlink(join(env.INPUT_DIR, input_files[0]), \
+                join(env.OUTPUT_DIR, dotfile))
+
+
+def _process_dotfiles(all_dotfiles_dict):
     for dotfile in all_dotfiles_dict:
-        ioutils.compile_dotfile(dotfile, all_dotfiles_dict[dotfile])
+        _process_dotfile(dotfile, all_dotfiles_dict[dotfile])
 
 
 def _revert_dotfiles(file_names):
@@ -178,7 +186,7 @@ def main():
             processed_dotfiles.append(dotfile)
         else:
             if dotfile in all_dotfiles_dict:
-                ioutils.compile_dotfile(dotfile, all_dotfiles_dict[dotfile])
+                _process_dotfile(dotfile, all_dotfiles_dict[dotfile])
                 processed_dotfiles.append(dotfile)
             else:
                 eprint(
@@ -191,7 +199,7 @@ def main():
         if env.ARGS.revert:
             _revert_dotfiles(all_dotfiles)
         else:
-            _compile_dotfiles(all_dotfiles_dict)
+            _process_dotfiles(all_dotfiles_dict)
         processed_dotfiles.extend(all_dotfiles)
     _print_completion_message(processed_dotfiles)
 

--- a/dotfilesmanager/dfm.py
+++ b/dotfilesmanager/dfm.py
@@ -156,11 +156,13 @@ def _get_dotfiles_dict(input_dir):
 
 
 def _process_dotfile(dotfile, input_files):
+    sprint("Processing file: " + dotfile)
     if len(input_files) > 1:
         ioutils.compile_dotfile(dotfile, input_files)
     else:
         ioutils.create_symlink(join(env.INPUT_DIR, input_files[0]), \
                 join(env.OUTPUT_DIR, dotfile))
+    sprint("Done with {0}\n".format(dotfile))
 
 
 def _process_dotfiles(all_dotfiles_dict):

--- a/dotfilesmanager/ioutils.py
+++ b/dotfilesmanager/ioutils.py
@@ -1,7 +1,7 @@
 import glob
 import io
 import os
-from os.path import join, isfile
+from os.path import join, isfile, islink
 import shutil
 import sys
 import time
@@ -66,8 +66,11 @@ def _write_input_file_contents(file_name, out_buffer):
 
 
 def _write_output_file(file_path, contents):
-    if not env.ARGS.clobber and isfile(file_path):
-        _back_up_file(file_path)
+    if not env.ARGS.clobber:
+        if islink(file_path):
+            _remove_symlink(file_path)
+        elif isfile(file_path):
+            _back_up_file(file_path)
     sprint("\tWriting input file contents to output file " + file_path)
     if not env.ARGS.dry_run:
         with open(file_path, 'w') as output_file:
@@ -102,3 +105,7 @@ def revert_dotfile(dotfile):
 
 def create_symlink(target, source):
     os.symlink(target, source)
+
+
+def _remove_symlink(link):
+    os.unlink(link)

--- a/dotfilesmanager/ioutils.py
+++ b/dotfilesmanager/ioutils.py
@@ -98,3 +98,7 @@ def revert_dotfile(dotfile):
                     shutil.copy(bak_file, join(env.OUTPUT_DIR, dotfile))
     else:
         eprint("No backup files found matching {0}".format(dotfile))
+
+
+def create_symlink(target, source):
+    os.symlink(target, source)

--- a/dotfilesmanager/test/test_dotfilesmanager.py
+++ b/dotfilesmanager/test/test_dotfilesmanager.py
@@ -259,5 +259,22 @@ class TestDotfilesManager(unittest.TestCase):
         symlink.assert_called_once_with(input_file, output_file)
 
 
+    @mock.patch('os.path.isdir', return_value=True)
+    @mock.patch('dotfilesmanager.dfm._set_args')
+    @mock.patch('dotfilesmanager.dfm.ioutils.compile_dotfile')
+    @mock.patch('dotfilesmanager.dfm.ioutils.create_symlink')
+    @mock.patch('dotfilesmanager.dfm._get_dotfiles_dict', return_value={'.fooconfig' : ['fooconfig']})
+    def test_symlinks_not_created_when_arg_no_symlinks(self, get_dotfiles_dict, create_symlink, compile_dotfile, set_args, isdir):
+        env.ARGS = env.parser.parse_args(['some_dir', '--no-symlinks'])
+
+        dfm.main()
+
+        dotfile = '.fooconfig'
+        input_files = ['fooconfig']
+
+        create_symlink.assert_not_called()
+        compile_dotfile.assert_called_once_with(dotfile, input_files)
+
+
 if __name__ == '__main__':
     unittest.main(module=__name__, buffer=True, exit=False)

--- a/dotfilesmanager/test/test_dotfilesmanager.py
+++ b/dotfilesmanager/test/test_dotfilesmanager.py
@@ -240,5 +240,24 @@ class TestDotfilesManager(unittest.TestCase):
         remove_symlink.assert_called_once()
 
 
+    @mock.patch('os.path.isdir', return_value=True)
+    @mock.patch('dotfilesmanager.dfm._set_args')
+    @mock.patch('dotfilesmanager.ioutils.os.readlink', return_value='vimrc')
+    @mock.patch('dotfilesmanager.dfm.ioutils._back_up_file')
+    @mock.patch('dotfilesmanager.dfm.ioutils.islink', return_value=False)
+    @mock.patch('dotfilesmanager.dfm.ioutils.isfile', return_value=True)
+    @mock.patch('dotfilesmanager.dfm.ioutils.os.symlink')
+    @mock.patch('dotfilesmanager.dfm._get_dotfiles_dict', return_value={'.fooconfig' : ['fooconfig']})
+    def test_existing_dotfile_replaced_with_symlink_when_single_input_file(self, get_dotfiles_dict, symlink, isfile, islink, back_up_file, readlink, set_args, isdir):
+        env.ARGS = env.parser.parse_args(['some_dir'])
+
+        dfm.main()
+
+        input_file = join(env.INPUT_DIR, 'fooconfig')
+        output_file = join(env.OUTPUT_DIR, '.fooconfig')
+        back_up_file.assert_called_once_with(output_file)
+        symlink.assert_called_once_with(input_file, output_file)
+
+
 if __name__ == '__main__':
     unittest.main(module=__name__, buffer=True, exit=False)

--- a/dotfilesmanager/test/test_dotfilesmanager.py
+++ b/dotfilesmanager/test/test_dotfilesmanager.py
@@ -216,10 +216,28 @@ class TestDotfilesManager(unittest.TestCase):
     @mock.patch('dotfilesmanager.dfm._get_dotfiles_dict', return_value={'.fooconfig' : ['fooconfig']})
     def test_symlink_created_when_single_input_file(self, get_dotfiles_dict, create_symlink, set_args, isdir):
         env.ARGS = env.parser.parse_args(['some_dir'])
+
         dfm.main()
 
         create_symlink.assert_called_once_with(join(env.INPUT_DIR, 'fooconfig'), \
                 join(env.OUTPUT_DIR, '.fooconfig'))
+
+
+    @mock.patch('builtins.open')
+    @mock.patch('dotfilesmanager.ioutils._remove_symlink')
+    @mock.patch('dotfilesmanager.ioutils.islink', return_value=True)
+    @mock.patch('dotfilesmanager.dfm.ioutils._back_up_file')
+    @mock.patch('os.path.isdir', return_value=True)
+    @mock.patch('dotfilesmanager.dfm._set_args')
+    @mock.patch('dotfilesmanager.dfm.ioutils.create_symlink')
+    @mock.patch('dotfilesmanager.dfm._get_dotfiles_dict', return_value={'.fooconfig' : ['99-fooconfig', 'fooconfig']})
+    def test_existing_symlink_removed_when_multiple_input_files(self, get_dotfiles_dict, create_symlink, set_args, isdir, back_up_file, islink, remove_symlink, m_open):
+        env.ARGS = env.parser.parse_args(['some_dir'])
+
+        dfm.main()
+
+        back_up_file.assert_not_called()
+        remove_symlink.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/dotfilesmanager/test/test_dotfilesmanager_int.py
+++ b/dotfilesmanager/test/test_dotfilesmanager_int.py
@@ -25,12 +25,12 @@ class TestDotfilesManagerInt(unittest.TestCase):
         dfm.ioutils.env = env
         env.set_up()
         dfm._set_args()
-        cls.create_input_files(cls)
 
 
     def setUp(self):
         env.set_up()
         dfm._set_args()
+        self.create_input_files()
 
 
     def tearDown(self):
@@ -78,6 +78,7 @@ class TestDotfilesManagerInt(unittest.TestCase):
             self.assertTrue("some_newer_value" not in bashrc.read())
 
         self.clean_up_backups()
+
 
 if __name__ == '__main__':
     unittest.main(module=__name__, buffer=True, exit=False)

--- a/dotfilesmanager/test/test_ioutils.py
+++ b/dotfilesmanager/test/test_ioutils.py
@@ -69,7 +69,7 @@ class TestIOUtils(unittest.TestCase):
         return_value={'.fooconfig' : ['99-fooconfig', '98-fooconfig_local']})
     @mock.patch('dotfilesmanager.ioutils._write_output_file')
     def test_correct_output_file_name_written(self, _write_output_file, _get_dotfiles_dict):
-        dfm._compile_dotfiles(dfm._get_dotfiles_dict(env.INPUT_DIR))
+        dfm._process_dotfiles(dfm._get_dotfiles_dict(env.INPUT_DIR))
 
         _write_output_file.assert_called_with(join(env.OUTPUT_DIR, '.fooconfig'), ANY)
 

--- a/dotfilesmanager/test/test_ioutils.py
+++ b/dotfilesmanager/test/test_ioutils.py
@@ -137,5 +137,50 @@ class TestIOUtils(unittest.TestCase):
         sys.stdout = stdout
 
 
+    @mock.patch('dotfilesmanager.ioutils._back_up_file')
+    @mock.patch('dotfilesmanager.ioutils.isfile', return_value=True)
+    @mock.patch('dotfilesmanager.ioutils.os.symlink')
+    def test_symlink_not_created_when_arg_dry_run(self, symlink, isfile, back_up_file):
+        stdout = sys.stdout
+        out = io.StringIO()
+        sys.stdout = out
+        env.ARGS.dry_run = True
+        env.ARGS.verbose = True
+
+        ioutils.create_symlink('99-foorc', 'foorc')
+
+        symlink.assert_not_called()
+
+        sys.stdout = stdout
+
+
+    @mock.patch('dotfilesmanager.ioutils.os.symlink')
+    @mock.patch('dotfilesmanager.ioutils._remove_symlink')
+    @mock.patch('dotfilesmanager.ioutils.os.readlink', return_value='some_nonexistent_file')
+    @mock.patch('dotfilesmanager.ioutils.isfile', return_value=False)
+    def test_existing_broken_symlink_is_removed(self, isfile, readlink, remove_symlink, symlink):
+        link_target = join(env.INPUT_DIR, 'vimrc')
+        link_source = join(env.OUTPUT_DIR, '.vimrc')
+
+        ioutils.create_symlink(link_target, link_source)
+
+        remove_symlink.assert_called_once()
+        symlink.assert_called_with(link_target, link_source)
+
+
+    @mock.patch('dotfilesmanager.ioutils.os.symlink')
+    @mock.patch('dotfilesmanager.ioutils._remove_symlink')
+    @mock.patch('dotfilesmanager.ioutils.os.readlink', return_value='vimrc')
+    @mock.patch('dotfilesmanager.ioutils.isfile', side_effect=[False, True])
+    def test_dont_try_to_recreate_existing_valid_symlink(self, isfile, readlink, remove_symlink, symlink):
+        link_target = 'vimrc'
+        link_source = join(env.OUTPUT_DIR, '.vimrc')
+
+        ioutils.create_symlink(link_target, link_source)
+
+        remove_symlink.assert_not_called()
+        symlink.assert_not_called()
+
+
 if __name__ == '__main__':
     unittest.main(module=__name__, buffer=True, exit=False)

--- a/dotfilesmanager/test/test_ioutils_int.py
+++ b/dotfilesmanager/test/test_ioutils_int.py
@@ -29,16 +29,15 @@ class TestIOUtilsInt(unittest.TestCase):
         dfm.ioutils.env = env
         env.set_up()
         dfm._set_args()
-        cls.create_input_files(cls)
 
 
     def setUp(self):
         env.set_up()
         dfm._set_args()
+        self.create_input_files()
 
 
-    @classmethod
-    def tearDownClass(cls):
+    def tearDown(self):
         env.tear_down()
 
 
@@ -78,7 +77,7 @@ class TestIOUtilsInt(unittest.TestCase):
         ioutils._create_file(join(env.INPUT_DIR, self.SECOND_INPUT_FILE), line_2)
         ioutils._create_file(join(env.INPUT_DIR, 'fooconfig'), line_3)
 
-        dfm._compile_dotfiles(dfm._get_dotfiles_dict(env.INPUT_DIR))
+        dfm._process_dotfiles(dfm._get_dotfiles_dict(env.INPUT_DIR))
 
         with open(join(env.OUTPUT_DIR, self.DOTFILE_NAME)) as fooconfig:
             file_contents = fooconfig.readlines()
@@ -93,7 +92,7 @@ class TestIOUtilsInt(unittest.TestCase):
         ioutils._create_file(join(env.OUTPUT_DIR, self.FIRST_INPUT_FILE), "some_token=some_value")
         ioutils._create_file(join(env.OUTPUT_DIR, self.SECOND_INPUT_FILE), "some_local_token=some_value")
 
-        dfm._compile_dotfiles(dfm._get_dotfiles_dict(env.INPUT_DIR))
+        dfm._process_dotfiles(dfm._get_dotfiles_dict(env.INPUT_DIR))
 
         with open(join(env.OUTPUT_DIR, self.DOTFILE_NAME)) as output_file:
             with open(join(env.INPUT_DIR, self.FIRST_INPUT_FILE)) as input_file:

--- a/dotfilesmanager/test/test_ioutils_int.py
+++ b/dotfilesmanager/test/test_ioutils_int.py
@@ -89,8 +89,9 @@ class TestIOUtilsInt(unittest.TestCase):
 
     def test_when_arg_e_then_specified_file_is_excluded(self):
         env.ARGS = env.parser.parse_args(['some_dir', '-e', self.SECOND_INPUT_FILE])
-        ioutils._create_file(join(env.OUTPUT_DIR, self.FIRST_INPUT_FILE), "some_token=some_value")
-        ioutils._create_file(join(env.OUTPUT_DIR, self.SECOND_INPUT_FILE), "some_local_token=some_value")
+        ioutils._create_file(join(env.INPUT_DIR, self.FIRST_INPUT_FILE), "some_token=some_value")
+        ioutils._create_file(join(env.INPUT_DIR, self.SECOND_INPUT_FILE), "some_local_token=some_value")
+        ioutils._create_file(join(env.INPUT_DIR, 'fooconfig'), "some_additional_token=some_value")
 
         dfm._process_dotfiles(dfm._get_dotfiles_dict(env.INPUT_DIR))
 
@@ -101,8 +102,14 @@ class TestIOUtilsInt(unittest.TestCase):
                     contents = output_file.read()
                     self.assertTrue(input_file.read() in contents)
                     self.assertTrue(local_input_file.read() not in contents)
-        env.ARGS = None
 
+
+    def test_backing_up_file_removes_original(self):
+        ioutils._create_file(join(env.OUTPUT_DIR, self.DOTFILE_NAME), "some_token=some_value")
+
+        ioutils._back_up_file(join(env.OUTPUT_DIR, self.DOTFILE_NAME))
+
+        self.assertFalse(os.path.isfile(join(env.OUTPUT_DIR, self.DOTFILE_NAME)))
 
 if __name__ == '__main__':
     unittest.main(module=__name__, buffer=True, exit=False)


### PR DESCRIPTION
When only one input file exists for a given dotfile, symlink to it rather than compiling a new output dotfile.
- Symlinking scenarios involved:
  - Replace existing dotfile with symlink
  - Remove existing symlink when compiling multiple input files
  - Don't try to back up symlinks
  - Handle existing valid, broken symlinks
- New switch --no-symlinks will disable symlinking