### PR TITLE
Handle first-run scenario (resolves #42)

### DIFF
--- a/dotfilesmanager/ioutils.py
+++ b/dotfilesmanager/ioutils.py
@@ -1,7 +1,7 @@
 import glob
 import io
 import os
-from os.path import join, isfile, islink
+from os.path import join, isfile, islink, exists
 import shutil
 import sys
 import time
@@ -32,7 +32,7 @@ def _back_up_file(file_name):
         file_name[file_name.rfind('/') + 1:]
         .replace('.', '') + '_' +
         timestamp + '.bak')
-    if not os.path.exists(env.BACKUPS_DIR):
+    if not exists(env.BACKUPS_DIR):
         sprint("Creating backups dir {0}".format(env.BACKUPS_DIR))
         if not env.ARGS.dry_run:
             os.mkdir(env.BACKUPS_DIR)
@@ -101,18 +101,19 @@ def revert_dotfile(dotfile):
 
 
 def create_symlink(target, source):
-    if isfile(source):
-        _back_up_file(source)
-    else:
-        existing_target = os.readlink(source)
-        if not isfile(existing_target):
-            sprint("\tExisting symlink {0} -> {1} is broken"\
-                    .format(source, existing_target))
-            _remove_symlink(source)
-        if target == existing_target:
-            sprint("\tSymlink {0} -> {1} already in place"\
-                    .format(source, target))
-            return
+    if exists(source):
+        if isfile(source):
+            _back_up_file(source)
+        else:
+            existing_target = os.readlink(source)
+            if not isfile(existing_target):
+                sprint("\tExisting symlink {0} -> {1} is broken"\
+                        .format(source, existing_target))
+                _remove_symlink(source)
+            if target == existing_target:
+                sprint("\tSymlink {0} -> {1} already in place"\
+                        .format(source, target))
+                return
     sprint("\tSymlinking {0} -> {1}".format(source, target))
     if not env.ARGS.dry_run:
         os.symlink(target, source)

--- a/dotfilesmanager/test/test_dotfilesmanager.py
+++ b/dotfilesmanager/test/test_dotfilesmanager.py
@@ -241,6 +241,7 @@ class TestDotfilesManager(unittest.TestCase):
 
 
     @mock.patch('os.path.isdir', return_value=True)
+    @mock.patch('dotfilesmanager.ioutils.exists', return_value=True)
     @mock.patch('dotfilesmanager.dfm._set_args')
     @mock.patch('dotfilesmanager.ioutils.os.readlink', return_value='vimrc')
     @mock.patch('dotfilesmanager.dfm.ioutils._back_up_file')
@@ -248,7 +249,7 @@ class TestDotfilesManager(unittest.TestCase):
     @mock.patch('dotfilesmanager.dfm.ioutils.isfile', return_value=True)
     @mock.patch('dotfilesmanager.dfm.ioutils.os.symlink')
     @mock.patch('dotfilesmanager.dfm._get_dotfiles_dict', return_value={'.fooconfig' : ['fooconfig']})
-    def test_existing_dotfile_replaced_with_symlink_when_single_input_file(self, get_dotfiles_dict, symlink, isfile, islink, back_up_file, readlink, set_args, isdir):
+    def test_existing_dotfile_replaced_with_symlink_when_single_input_file(self, get_dotfiles_dict, symlink, isfile, islink, back_up_file, readlink, set_args, exists, isdir):
         env.ARGS = env.parser.parse_args(['some_dir'])
 
         dfm.main()

--- a/dotfilesmanager/test/test_ioutils.py
+++ b/dotfilesmanager/test/test_ioutils.py
@@ -158,7 +158,8 @@ class TestIOUtils(unittest.TestCase):
     @mock.patch('dotfilesmanager.ioutils._remove_symlink')
     @mock.patch('dotfilesmanager.ioutils.os.readlink', return_value='some_nonexistent_file')
     @mock.patch('dotfilesmanager.ioutils.isfile', return_value=False)
-    def test_existing_broken_symlink_is_removed(self, isfile, readlink, remove_symlink, symlink):
+    @mock.patch('dotfilesmanager.ioutils.exists', return_value=True)
+    def test_existing_broken_symlink_is_removed(self, exists, isfile, readlink, remove_symlink, symlink):
         link_target = join(env.INPUT_DIR, 'vimrc')
         link_source = join(env.OUTPUT_DIR, '.vimrc')
 
@@ -172,7 +173,8 @@ class TestIOUtils(unittest.TestCase):
     @mock.patch('dotfilesmanager.ioutils._remove_symlink')
     @mock.patch('dotfilesmanager.ioutils.os.readlink', return_value='vimrc')
     @mock.patch('dotfilesmanager.ioutils.isfile', side_effect=[False, True])
-    def test_dont_try_to_recreate_existing_valid_symlink(self, isfile, readlink, remove_symlink, symlink):
+    @mock.patch('dotfilesmanager.ioutils.exists', return_value=True)
+    def test_dont_try_to_recreate_existing_valid_symlink(self, exists, isfile, readlink, remove_symlink, symlink):
         link_target = 'vimrc'
         link_source = join(env.OUTPUT_DIR, '.vimrc')
 
@@ -180,6 +182,19 @@ class TestIOUtils(unittest.TestCase):
 
         remove_symlink.assert_not_called()
         symlink.assert_not_called()
+
+
+    @mock.patch('dotfilesmanager.ioutils.os.symlink')
+    @mock.patch('dotfilesmanager.ioutils._remove_symlink')
+    @mock.patch('dotfilesmanager.ioutils.exists', return_value=False)
+    def test_no_existing_symlink_source(self, exists, remove_symlink, symlink):
+        link_target = 'vimrc'
+        link_source = join(env.OUTPUT_DIR, '.vimrc')
+
+        ioutils.create_symlink(link_target, link_source)
+
+        remove_symlink.assert_not_called()
+        symlink.assert_called_once()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When symlinking, handle scenario where there is no existing symlink and no existing file (e.g. brand new system or first-time introduction of a particular dotfile).