### PR TITLE
Handle directory separators more consistently

### DIFF
--- a/dotfilesmanager/dfm.py
+++ b/dotfilesmanager/dfm.py
@@ -4,10 +4,10 @@ import itertools
 import re
 import sys
 import os
-from os.path import join
+from os.path import join, abspath, dirname
 import argparse
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(abspath(dirname(dirname(__file__))))
 
 from dotfilesmanager import env
 from dotfilesmanager import ioutils

--- a/dotfilesmanager/ioutils.py
+++ b/dotfilesmanager/ioutils.py
@@ -29,7 +29,7 @@ def _back_up_file(file_name):
     timestamp = time.strftime('%Y-%m-%d_%H-%M-%S')
     bak_file = join(
         env.BACKUPS_DIR,
-        file_name[file_name.rfind('/') + 1:]
+        file_name[file_name.rfind(os.sep) + 1:]
         .replace('.', '') + '_' +
         timestamp + '.bak')
     if not exists(env.BACKUPS_DIR):

--- a/dotfilesmanager/test/env.py
+++ b/dotfilesmanager/test/env.py
@@ -18,9 +18,9 @@ def set_up():
     global BACKUPS_DIR
     global parser
     global ARGS
-    INPUT_DIR = join(_TMP_DIR, 'testsrc/')
-    OUTPUT_DIR = join(_TMP_DIR, 'testoutputfiles/')
-    BACKUPS_DIR = join(_TMP_DIR, 'testbackups/')
+    INPUT_DIR = join(_TMP_DIR, 'testsrc')
+    OUTPUT_DIR = join(_TMP_DIR, 'testoutputfiles')
+    BACKUPS_DIR = join(_TMP_DIR, 'testbackups')
     parser = argparse.ArgumentParser()
     ARGS = None
     _set_up_dirs()

--- a/dotfilesmanager/test/test_dotfilesmanager.py
+++ b/dotfilesmanager/test/test_dotfilesmanager.py
@@ -1,14 +1,12 @@
-#!/usr/bin/env python3.6
-
 import io
 import os
-from os.path import join
+from os.path import join, abspath, dirname
 import sys
 import unittest
 from unittest import mock
 from unittest.mock import call
 
-sys.path.append(os.path.abspath(join(os.path.dirname(__file__), '../..')))
+sys.path.append(abspath(dirname(dirname(dirname(__file__)))))
 
 from dotfilesmanager import dfm, ioutils
 from dotfilesmanager.test import env

--- a/dotfilesmanager/test/test_dotfilesmanager_int.py
+++ b/dotfilesmanager/test/test_dotfilesmanager_int.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3.6
-
 import os
 from os.path import join
 import shutil
@@ -16,7 +14,7 @@ class TestDotfilesManagerInt(unittest.TestCase):
     SECOND_INPUT_FILE = '98-fooconfig_local'
 
     DOTFILE_NAME = '.fooconfig'
-    BACKUP_FILE_NAME = DOTFILE_NAME[DOTFILE_NAME.rfind('/') + 1 :].replace('.', '')
+    BACKUP_FILE_NAME = DOTFILE_NAME[DOTFILE_NAME.rfind(os.sep) + 1 :].replace('.', '')
 
 
     @classmethod

--- a/dotfilesmanager/test/test_ioutils.py
+++ b/dotfilesmanager/test/test_ioutils.py
@@ -1,14 +1,12 @@
-#!/usr/bin/env python3.6
-
 import io
 import os
-from os.path import join
+from os.path import join, abspath, dirname
 import sys
 import unittest
 from unittest import mock
 from unittest.mock import ANY
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+sys.path.append(abspath(dirname(dirname(dirname(__file__)))))
 
 from dotfilesmanager.test import env
 from dotfilesmanager import dfm

--- a/dotfilesmanager/test/test_ioutils_int.py
+++ b/dotfilesmanager/test/test_ioutils_int.py
@@ -1,13 +1,11 @@
-#!/usr/bin/env python3.6
-
 import io
 import os
-from os.path import join
+from os.path import join, abspath, dirname
 import shutil
 import sys
 import unittest
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+sys.path.append(abspath(dirname(dirname(__file__))))
 
 from dotfilesmanager.test import env
 from dotfilesmanager import dfm
@@ -20,7 +18,7 @@ class TestIOUtilsInt(unittest.TestCase):
     SECOND_INPUT_FILE = '98-fooconfig_local'
 
     DOTFILE_NAME = '.fooconfig'
-    BACKUP_FILE_NAME = DOTFILE_NAME[DOTFILE_NAME.rfind('/') + 1 :].replace('.', '')
+    BACKUP_FILE_NAME = DOTFILE_NAME[DOTFILE_NAME.rfind(os.sep) + 1 :].replace('.', '')
 
 
     @classmethod


### PR DESCRIPTION
- Use `os.sep` instead of `'/'`
- Use `os.path.dirname` instead of `join(foo, '..')`
- Remove unneeded shebangs from test files