### PR TITLE
Exclude files in dirs specified by -e (resolves #63).

### DIFF
--- a/dotfilesmanager/dfm.py
+++ b/dotfilesmanager/dfm.py
@@ -157,7 +157,9 @@ def _is_input_file_excluded(config: Config, file_name: str) -> bool:
         return False
     all_excludes = list(itertools.chain.from_iterable(config.args.exclude))
     normalized_excludes = [os.path.normpath(item) for item in all_excludes]
-    return file_name in normalized_excludes
+    return file_name in normalized_excludes or any(
+        file_name.startswith(excl + os.sep) for excl in normalized_excludes
+    )
 
 
 def _is_binary_file(config: Config, file_name: str) -> bool:

--- a/tests/test_dotfilesmanager.py
+++ b/tests/test_dotfilesmanager.py
@@ -152,6 +152,13 @@ class TestDotfilesManager:
         assert dfm._is_input_file_excluded(test_config, "vimrc_work")
         assert not dfm._is_input_file_excluded(test_config, "bashrc")
 
+    def test_is_input_file_excluded_when_excluded_dir(self, test_config):
+        """Test that files inside an excluded directory are also excluded."""
+        test_config.args.exclude = [["doom.d"]]
+        assert dfm._is_input_file_excluded(test_config, "doom.d/config.el")
+        assert dfm._is_input_file_excluded(test_config, "doom.d/init.el")
+        assert not dfm._is_input_file_excluded(test_config, "bashrc")
+
     def test_is_binary_file_detects_binary_content(self, test_config):
         """Test that binary files are detected by null bytes."""
         binary_file = test_config.input_dir / "test.swp"


### PR DESCRIPTION
` _is_input_file_excluded` in `dfm.py` did exact string matching, so `-e doom.d` never matched walked paths like `doom.d/config.el`. Added a prefix check so any path starting with an excluded name  + path separator is also excluded.